### PR TITLE
Fixing c pthreads

### DIFF
--- a/src/cmd/link/internal/ld/gosb2.go
+++ b/src/cmd/link/internal/ld/gosb2.go
@@ -211,6 +211,7 @@ func gosb_reorderSymbols(sel int, syms []*sym.Symbol) []*sym.Symbol {
 	regSyms := make([]*sym.Symbol, 0)
 	bloated := make(map[string][]*sym.Symbol)
 	sandSyms := make([]*sym.Symbol, 0)
+	specials := make([]*sym.Symbol, 0)
 	for _, s := range syms {
 		// Safety check to avoid go.itab and go.runtime
 		if s.File == "go.runtime" || s.File == "go.itab" {
@@ -227,6 +228,9 @@ func gosb_reorderSymbols(sel int, syms []*sym.Symbol) []*sym.Symbol {
 				e = make([]*sym.Symbol, 0)
 			}
 			bloated[s.File] = append(e, s)
+		} else if s.Name == "runtime.pclntab" {
+			s.Align = 0x1000
+			specials = append(specials, s)
 		} else {
 			regSyms = append(regSyms, s)
 		}
@@ -257,6 +261,7 @@ func gosb_reorderSymbols(sel int, syms []*sym.Symbol) []*sym.Symbol {
 		s[0].Align = 0x1000
 		regSyms = append(regSyms, s...)
 	}
+	regSyms = append(regSyms, specials...)
 	regSyms = append(regSyms, sandSyms...)
 	return regSyms
 }

--- a/src/gosb/gosb.go
+++ b/src/gosb/gosb.go
@@ -148,6 +148,19 @@ func loadPackages() {
 
 	// Make sure  Backend is removed from trusted.
 	globals.TrustedSpace.UnmapArea(globals.CommonVMAs)
+
+	// Update non-bloat
+	if pkg, ok := globals.NameToPkg[globals.TrustedPackages]; ok {
+		pkg.Sects = make([]commons.Section, 0)
+		globals.TrustedSpace.Foreach(func(e *commons.ListElem) {
+			vma := commons.ToVMA(e)
+			pkg.Sects = append(pkg.Sects, commons.Section{
+				vma.Addr,
+				vma.Size,
+				vma.Prot,
+			})
+		})
+	}
 }
 
 func loadSandboxes() {
@@ -238,7 +251,9 @@ func loadSandboxes() {
 		sbox.Dynamic = commons.Convert(dynamics)
 
 		// Add common parts
-		sbox.Static.MapAreaCopy(globals.CommonVMAs)
+		if sbox.Config.Id != globals.TrustedSandbox {
+			sbox.Static.MapAreaCopy(globals.CommonVMAs)
+		}
 		globals.Sandboxes[sbox.Config.Id] = sbox
 	}
 }

--- a/src/gosb/vtx/platform/kvm/bluepill_unsafe.go
+++ b/src/gosb/vtx/platform/kvm/bluepill_unsafe.go
@@ -161,6 +161,8 @@ func bluepillHandler(context unsafe.Pointer) {
 				default:
 					throw("invalid state")
 				}
+				// Make the vCPU available again.
+				atomic.SwapUint32(&c.state, vCPUReady)
 				return
 			case syshandlerErr1:
 				c.die(bluepillArchContext(context), "Invalid address")

--- a/src/gosb/vtx/platform/kvm/kvm.go
+++ b/src/gosb/vtx/platform/kvm/kvm.go
@@ -2,7 +2,6 @@ package kvm
 
 import (
 	"gosb/commons"
-	"gosb/debug"
 	mv "gosb/vtx/platform/memview"
 	"gosb/vtx/platform/ring0"
 	"log"
@@ -68,7 +67,6 @@ func (k *KVM) ExtendRuntime(heap bool, start, size uintptr, prot uint8) {
 	size = uintptr(commons.Round(uint64(size), true))
 	if k.Machine.MemView.ContainsRegion(start, size) {
 		// Nothing to do, we already mapped it.
-		debug.TakeValue(999)
 		return
 	}
 	// We have to map a new region.

--- a/src/gosb/vtx/platform/kvm/machine.go
+++ b/src/gosb/vtx/platform/kvm/machine.go
@@ -163,6 +163,15 @@ func (m *Machine) newVCPU() *vCPU {
 }
 
 //go:nosplit
+func (k *Machine) Replenish() {
+	for i := range k.EMR {
+		if k.EMR[i] == nil {
+			k.EMR[i] = &mv.MemoryRegion{}
+		}
+	}
+}
+
+//go:nosplit
 func (k *Machine) AcquireEMR() *mv.MemoryRegion {
 	//TODO(aghosn) probably need a lock
 	for i := range k.EMR {

--- a/src/gosb/vtx/platform/kvm/machine_amd64.go
+++ b/src/gosb/vtx/platform/kvm/machine_amd64.go
@@ -159,10 +159,10 @@ func (c *vCPU) SwitchToUser(switchOpts ring0.SwitchOpts, info *arch.SignalInfo) 
 	}
 	c.entered = true
 	rip := switchOpts.Registers.Rip
-	fs := switchOpts.Registers.Fs
+	fs := switchOpts.Registers.Fs_base
 	*switchOpts.Registers = *c.CPU.Registers()
 	switchOpts.Registers.Rip = rip
-	switchOpts.Registers.Fs = fs
+	switchOpts.Registers.Fs_base = fs
 	switchOpts.Registers.Rsp = switchOpts.Registers.Rbp + 8
 	switchOpts.Registers.Rbp = *((*uint64)(unsafe.Pointer(uintptr(switchOpts.Registers.Rbp))))
 	c.CPU.SwitchToUser(switchOpts)

--- a/src/gosb/vtx/platform/memview/full_space.go
+++ b/src/gosb/vtx/platform/memview/full_space.go
@@ -79,13 +79,3 @@ func ParseProcessAddressSpace(defProt uint8) []*commons.VMArea {
 	}
 	return vmareas
 }
-
-func ToPatch(addr uint64) *commons.VMArea {
-	areas := ParseProcessAddressSpace(commons.D_VAL)
-	for _, v := range areas {
-		if v.Addr <= addr && v.Addr+v.Size > addr {
-			return v
-		}
-	}
-	return nil
-}

--- a/src/gosb/vtx/platform/memview/full_space.go
+++ b/src/gosb/vtx/platform/memview/full_space.go
@@ -79,3 +79,13 @@ func ParseProcessAddressSpace(defProt uint8) []*commons.VMArea {
 	}
 	return vmareas
 }
+
+func ToPatch(addr uint64) *commons.VMArea {
+	areas := ParseProcessAddressSpace(commons.D_VAL)
+	for _, v := range areas {
+		if v.Addr <= addr && v.Addr+v.Size > addr {
+			return v
+		}
+	}
+	return nil
+}

--- a/src/gosb/vtx/platform/memview/memview.go
+++ b/src/gosb/vtx/platform/memview/memview.go
@@ -324,10 +324,10 @@ func (m *MemoryRegion) Print() {
 	switch m.Tpe {
 	case IMMUTABLE_REG:
 		for v := commons.ToVMA(m.View.First); v != nil; v = commons.ToVMA(v.Next) {
-			fmt.Printf("%x -- %x (%x)\n", v.Addr, v.Addr+v.Size, v.Prot)
+			fmt.Printf("%x -- %x [%x] (%x)\n", v.Addr, v.Addr+v.Size, v.Size, v.Prot)
 		}
 	default:
-		fmt.Printf("%x -- %x (%x)\n", m.Span.Start, m.Span.Start+m.Span.Size, m.Span.Prot)
+		fmt.Printf("%x -- %x [%x] (%x)\n", m.Span.Start, m.Span.Start+m.Span.Size, m.Span.Size, m.Span.Prot)
 	}
 }
 

--- a/src/runtime/cgo_mmap.go
+++ b/src/runtime/cgo_mmap.go
@@ -36,7 +36,6 @@ func mmap(addr unsafe.Pointer, n uintptr, prot, flags, fd int32, off uint32) (un
 		}
 		if runtimeGrowth != nil {
 			runtimeGrowth(false, 0, uintptr(ret), n)
-			TakeValue(uintptr(ret))
 		}
 		return unsafe.Pointer(ret), 0
 	}
@@ -56,7 +55,6 @@ func sysMmap(addr unsafe.Pointer, n uintptr, prot, flags, fd int32, off uint32) 
 	p, err = sysMmap2(addr, n, prot, flags, fd, off)
 	if runtimeGrowth != nil {
 		runtimeGrowth(false, 0, uintptr(p), n)
-		TakeValue(uintptr(p))
 	}
 	return p, err
 }


### PR DESCRIPTION
Cgo relies on pthread to spawn new thread.
It uses the default TLS provided by libc which, as result, makes it unavailable to our sandbox.
To fix this, we ask g0 to provide us with the correct values for the thread g0 stack and its TLS